### PR TITLE
Fixed incorrect handling of negative timezone offsets.

### DIFF
--- a/config.py
+++ b/config.py
@@ -85,7 +85,7 @@ assert(NUMBER_OF_TEASER_ARTICLES > -1)
 assert(type(NUMBER_OF_FEED_ARTICLES) == int)
 assert(NUMBER_OF_FEED_ARTICLES > -1)
 
-assert(TIME_ZONE_ADDON[0] == (u'+' or u'-'))
+assert(TIME_ZONE_ADDON[0] in (u'+', u'-'))
 
 
 def assertTag(tag):


### PR DESCRIPTION
The assert() logic in config.py was incorrect for negative timezone offsets.  Since you live in a positive timezone you probably never saw this problem.  The "or" Python operator doesn't work the way the old code did things.