### PR TITLE
mkdir --parents does not exist on FreeBSD

### DIFF
--- a/example_invocation.sh
+++ b/example_invocation.sh
@@ -3,7 +3,7 @@
 # rm -rf testdata/2del/*
 
 # create the output directory (and parents):
-mkdir --parents testdata/2del/blog
+mkdir -p testdata/2del/blog
 
 
 # get help on the following parameters: «python ./lazyblorg.py --help»


### PR DESCRIPTION
The short form of the parameter "-p" exists in all mkdir variants I know (FreeBSD, Linux, OSX).