### PR TITLE
Modified `sanitize_feed_html_characters` to escape `&` characters 

### DIFF
--- a/lib/htmlizer.py
+++ b/lib/htmlizer.py
@@ -1709,6 +1709,8 @@ class Htmlizer(object):
         @param return: sanitized string
         """
 
+        content = content.replace('&amp;', '&').replace('&', '&amp;')
+
         return content.replace(
             '<script async src=',
             '<script async="async" src=').replace(

--- a/lib/htmlizer.py
+++ b/lib/htmlizer.py
@@ -1709,7 +1709,8 @@ class Htmlizer(object):
         @param return: sanitized string
         """
 
-        content = content.replace('&amp;', '&').replace('&', '&amp;')
+        # content = content.replace('&amp;', '&').replace('&', '&amp;')
+        content = re.sub("&(?!amp;)", "&amp;", content)
 
         return content.replace(
             '<script async src=',

--- a/testdata/end_to_end_test/orgfiles/test_case_sanitizing.org
+++ b/testdata/end_to_end_test/orgfiles/test_case_sanitizing.org
@@ -23,6 +23,20 @@ CLOSED: [2017-01-08 Sun 10:58]
 )
 #+END_SRC
 
+Here comes some HTML to test for https://github.com/novoid/lazyblorg/issues/24#issuecomment-759594835:
+
+#+NAME: my-HTML-example name
+#+BEGIN_HTML
+    foo
+bar
+  <foo />
+<a href="bar">baz</a>
+<a href="https://problemurl.com?a=b>ok</a>
+<a href="https://problemurl.com?a=b&c=d">ok cool</a>
+<a href="https://problemurl.com?a=b&c=d&more=merrier">ok</a>
+<a href="https://problemurl.com?a=b&c=d&evenmore&=evenmerrier&">ok</a>
+#+END_HTML
+
 A simple code block:
 
 : \** Cabaret `(my-capture-prompt "date of event" 'my-event-date)`: `(my-capture-prompt "artist" 'my-artist)`


### PR DESCRIPTION
This PR does not resolve #24, but I think it fixes the current feed problem.


...

![2021-01-13_20-00-55](https://user-images.githubusercontent.com/527767/104497642-f49b9300-55da-11eb-9746-10ff32056b48.png)

(the full feed on the screenshot fails because there is a testcase with a `<this>` tag which is not closed. not sure this exists in real data.)


