### PR TITLE
change local links in RSS feed to global

### DIFF
--- a/lib/htmlizer.py
+++ b/lib/htmlizer.py
@@ -749,6 +749,8 @@ class Htmlizer(object):
             teaser_atom_feed = teaser_atom_feed.replace('\'' + config.BASE_URL, '\'http:' + config.BASE_URL)
             content_atom_feed = content_atom_feed.replace('>' + config.BASE_URL, '>http:' + config.BASE_URL)
             content_atom_feed = content_atom_feed.replace('\'' + config.BASE_URL, '\'http:' + config.BASE_URL)
+            teaser_atom_feed = teaser_atom_feed.replace('href="' + config.BASE_URL, 'href="https:' + config.BASE_URL)
+            content_atom_feed = content_atom_feed.replace('href="' + config.BASE_URL, 'href="https:' + config.BASE_URL)
 
             number_of_current_feed_entries += 1
 

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry1/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry1/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry1%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry1%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry1%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry1%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry10/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry10/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry10%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry10%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry10%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry10%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry11/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry11/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry11%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry11%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry11%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry11%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry12/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry12/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry12%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry12%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry12%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry12%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry13/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry13/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry13%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry13%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry13%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry13%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry14/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry14/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry14%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry14%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry14%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry14%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry2/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry2/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry2%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry2%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry2%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry2%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry3/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry3/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry3%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry3%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry3%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry3%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry4/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry4/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry4%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry4%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry4%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry4%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry5/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry5/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry5%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry5%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry5%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry5%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry6/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry6/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry6%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry6%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry6%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry6%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry7/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry7/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry7%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry7%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry7%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry7%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry8/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry8/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry8%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry8%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry8%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry8%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/1985/01/01/old-entry9/index.html
+++ b/testdata/end_to_end_test/comparison/1985/01/01/old-entry9/index.html
@@ -113,7 +113,7 @@ Test entry.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry9%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry9%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=1985-01-01-old-entry9%20comment:%20&body=Please%20do%20not%20remove%20'1985-01-01-old-entry9%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2013/02/14/lazyblorg-example-entry/index.html
+++ b/testdata/end_to_end_test/comparison/2013/02/14/lazyblorg-example-entry/index.html
@@ -175,7 +175,7 @@ bar<br />
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2013-02-12-lazyblorg-example-entry%20comment:%20&body=Please%20do%20not%20remove%20'2013-02-12-lazyblorg-example-entry%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2013-02-12-lazyblorg-example-entry%20comment:%20&body=Please%20do%20not%20remove%20'2013-02-12-lazyblorg-example-entry%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2013/08/22/testid/index.html
+++ b/testdata/end_to_end_test/comparison/2013/08/22/testid/index.html
@@ -113,7 +113,7 @@ Just for testing.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2013-08-22-testid%20comment:%20&body=Please%20do%20not%20remove%20'2013-08-22-testid%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2013-08-22-testid%20comment:%20&body=Please%20do%20not%20remove%20'2013-08-22-testid%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2014/01/30/full-syntax-test/index.html
+++ b/testdata/end_to_end_test/comparison/2014/01/30/full-syntax-test/index.html
@@ -1003,7 +1003,7 @@ The following snippet would result in an error if it was not just a comment: "im
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2014-01-27-full-syntax-test%20comment:%20&body=Please%20do%20not%20remove%20'2014-01-27-full-syntax-test%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2014-01-27-full-syntax-test%20comment:%20&body=Please%20do%20not%20remove%20'2014-01-27-full-syntax-test%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2016/09/18/from-nothing-to-done/index.html
+++ b/testdata/end_to_end_test/comparison/2016/09/18/from-nothing-to-done/index.html
@@ -114,7 +114,7 @@ This is an example blog entry with no special content.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-09-18-from-nothing-to-done%20comment:%20&body=Please%20do%20not%20remove%20'2016-09-18-from-nothing-to-done%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-09-18-from-nothing-to-done%20comment:%20&body=Please%20do%20not%20remove%20'2016-09-18-from-nothing-to-done%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2016/10/31/an-hidden-blog-entry/index.html
+++ b/testdata/end_to_end_test/comparison/2016/10/31/an-hidden-blog-entry/index.html
@@ -134,7 +134,7 @@ Novum possit temporibus his in. Eam ut scripserit reformidans conclusionemque. O
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-10-31-an-hidden-blog-entry%20comment:%20&body=Please%20do%20not%20remove%20'2016-10-31-an-hidden-blog-entry%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-10-31-an-hidden-blog-entry%20comment:%20&body=Please%20do%20not%20remove%20'2016-10-31-an-hidden-blog-entry%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2016/10/31/my-temporal-article/index.html
+++ b/testdata/end_to_end_test/comparison/2016/10/31/my-temporal-article/index.html
@@ -145,7 +145,7 @@ Novum possit temporibus his in. Eam ut scripserit reformidans conclusionemque. O
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-10-31-my-temporal-article%20comment:%20&body=Please%20do%20not%20remove%20'2016-10-31-my-temporal-article%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-10-31-my-temporal-article%20comment:%20&body=Please%20do%20not%20remove%20'2016-10-31-my-temporal-article%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2016/11/06/sanitization-examples/index.html
+++ b/testdata/end_to_end_test/comparison/2016/11/06/sanitization-examples/index.html
@@ -143,7 +143,7 @@ Maybe <this> should not be sanitized?<div class="orgmode-hr" ></div><ul>
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-11-06-sanitization-examples%20comment:%20&body=Please%20do%20not%20remove%20'2016-11-06-sanitization-examples%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-11-06-sanitization-examples%20comment:%20&body=Please%20do%20not%20remove%20'2016-11-06-sanitization-examples%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2016/11/16/empty-language-autotag-page/index.html
+++ b/testdata/end_to_end_test/comparison/2016/11/16/empty-language-autotag-page/index.html
@@ -142,7 +142,7 @@ Autotags sind tags wie beispielsweise 'language:english' oder 'size:small' und s
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=empty-language-autotag-page%20comment:%20&body=Please%20do%20not%20remove%20'empty-language-autotag-page%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=empty-language-autotag-page%20comment:%20&body=Please%20do%20not%20remove%20'empty-language-autotag-page%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2016/11/27/image-test/index.html
+++ b/testdata/end_to_end_test/comparison/2016/11/27/image-test/index.html
@@ -215,7 +215,7 @@ FIXXME: not tested so far:
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-11-27-image-test%20comment:%20&body=Please%20do%20not%20remove%20'2016-11-27-image-test%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-11-27-image-test%20comment:%20&body=Please%20do%20not%20remove%20'2016-11-27-image-test%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2016/11/27/special-characters/index.html
+++ b/testdata/end_to_end_test/comparison/2016/11/27/special-characters/index.html
@@ -126,7 +126,7 @@ Being curious how this is going to work out.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-11-27-special-characters%20comment:%20&body=Please%20do%20not%20remove%20'2016-11-27-special-characters%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-11-27-special-characters%20comment:%20&body=Please%20do%20not%20remove%20'2016-11-27-special-characters%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2017/01/08/sanitizing-tests/index.html
+++ b/testdata/end_to_end_test/comparison/2017/01/08/sanitizing-tests/index.html
@@ -182,7 +182,7 @@ Test case for two ampersants in an URL, causing an issue in the feed: <a href="h
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2017-01-08-sanitizing-tests%20comment:%20&body=Please%20do%20not%20remove%20'2017-01-08-sanitizing-tests%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2017-01-08-sanitizing-tests%20comment:%20&body=Please%20do%20not%20remove%20'2017-01-08-sanitizing-tests%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2017/09/30/link-test/index.html
+++ b/testdata/end_to_end_test/comparison/2017/09/30/link-test/index.html
@@ -209,7 +209,7 @@ This is to test the reading length estimation algorithm with a property drawer a
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2017-09-30-link-test%20comment:%20&body=Please%20do%20not%20remove%20'2017-09-30-link-test%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2017-09-30-link-test%20comment:%20&body=Please%20do%20not%20remove%20'2017-09-30-link-test%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2020/10/02/Heading-which-starts-with-a-list/index.html
+++ b/testdata/end_to_end_test/comparison/2020/10/02/Heading-which-starts-with-a-list/index.html
@@ -119,7 +119,7 @@
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2020-10-02-Heading-which-starts-with-a-list%20comment:%20&body=Please%20do%20not%20remove%20'2020-10-02-Heading-which-starts-with-a-list%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2020-10-02-Heading-which-starts-with-a-list%20comment:%20&body=Please%20do%20not%20remove%20'2020-10-02-Heading-which-starts-with-a-list%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/2021/01/30/drawer-tests/index.html
+++ b/testdata/end_to_end_test/comparison/2021/01/30/drawer-tests/index.html
@@ -123,7 +123,7 @@ Another dummy text.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2021-01-30-drawer-tests%20comment:%20&body=Please%20do%20not%20remove%20'2021-01-30-drawer-tests%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2021-01-30-drawer-tests%20comment:%20&body=Please%20do%20not%20remove%20'2021-01-30-drawer-tests%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/about/index.html
+++ b/testdata/end_to_end_test/comparison/about/index.html
@@ -93,7 +93,7 @@ This is a placeholder entry in order to be able to test internal links.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2014-03-09-about%20comment:%20&body=Please%20do%20not%20remove%20'2014-03-09-about%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2014-03-09-about%20comment:%20&body=Please%20do%20not%20remove%20'2014-03-09-about%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/feeds/lazyblorg-all.atom_1.0.links-and-content.xml
+++ b/testdata/end_to_end_test/comparison/feeds/lazyblorg-all.atom_1.0.links-and-content.xml
@@ -97,21 +97,21 @@ This is a test article which tests its links to other (internal) blog entries.
 </p>
 
 <ul>
-<li>This should work <a href="//Karl-Voit.at/persistent-entry">in lists</a> as <a href="//Karl-Voit.at/2016/11/27/special-characters">well</a>.</li>
-<li>This should work <a href="//Karl-Voit.at/persistent-entry">2016-10-31-persistent-entry</a> and <a href="//Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a>.</li>
+<li>This should work <a href="https://Karl-Voit.at/persistent-entry">in lists</a> as <a href="https://Karl-Voit.at/2016/11/27/special-characters">well</a>.</li>
+<li>This should work <a href="https://Karl-Voit.at/persistent-entry">2016-10-31-persistent-entry</a> and <a href="https://Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a>.</li>
 </ul>
 
 <table>
 <tbody>
 <tr class="odd">
 <td>also in</td>
-<td>a <a href="//Karl-Voit.at/2016/11/27/special-characters">table</a></td>
-<td>with <a href="//Karl-Voit.at/2016/11/27/special-characters">multiple cells containing links</a></td>
+<td>a <a href="https://Karl-Voit.at/2016/11/27/special-characters">table</a></td>
+<td>with <a href="https://Karl-Voit.at/2016/11/27/special-characters">multiple cells containing links</a></td>
 </tr>
 <tr class="even">
 <td>also</td>
-<td><a href="//Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
-<td>and <a href="//Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
+<td><a href="https://Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
+<td>and <a href="https://Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
 </tr>
 </tbody>
 </table>
@@ -122,7 +122,7 @@ This is a test article which tests its links to other (internal) blog entries.
 
 <p>
 
-Here is <a href="//Karl-Voit.at/2017/09/30/link-test">a self-reference</a> which should not result in a backlink to itself.
+Here is <a href="https://Karl-Voit.at/2017/09/30/link-test">a self-reference</a> which should not result in a backlink to itself.
 
 </p>
 </div>
@@ -136,21 +136,21 @@ This is a test article which tests its links to other (internal) blog entries.
 </p>
 
 <ul>
-<li>This should work <a href="//Karl-Voit.at/persistent-entry">in lists</a> as <a href="//Karl-Voit.at/2016/11/27/special-characters">well</a>.</li>
-<li>This should work <a href="//Karl-Voit.at/persistent-entry">2016-10-31-persistent-entry</a> and <a href="//Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a>.</li>
+<li>This should work <a href="https://Karl-Voit.at/persistent-entry">in lists</a> as <a href="https://Karl-Voit.at/2016/11/27/special-characters">well</a>.</li>
+<li>This should work <a href="https://Karl-Voit.at/persistent-entry">2016-10-31-persistent-entry</a> and <a href="https://Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a>.</li>
 </ul>
 
 <table>
 <tbody>
 <tr class="odd">
 <td>also in</td>
-<td>a <a href="//Karl-Voit.at/2016/11/27/special-characters">table</a></td>
-<td>with <a href="//Karl-Voit.at/2016/11/27/special-characters">multiple cells containing links</a></td>
+<td>a <a href="https://Karl-Voit.at/2016/11/27/special-characters">table</a></td>
+<td>with <a href="https://Karl-Voit.at/2016/11/27/special-characters">multiple cells containing links</a></td>
 </tr>
 <tr class="even">
 <td>also</td>
-<td><a href="//Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
-<td>and <a href="//Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
+<td><a href="https://Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
+<td>and <a href="https://Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
 </tr>
 </tbody>
 </table>
@@ -161,17 +161,17 @@ This is a test article which tests its links to other (internal) blog entries.
 
 <p>
 
-Here is <a href="//Karl-Voit.at/2017/09/30/link-test">a self-reference</a> which should not result in a backlink to itself.
+Here is <a href="https://Karl-Voit.at/2017/09/30/link-test">a self-reference</a> which should not result in a backlink to itself.
 
 </p>
 
 
-	  <header><h2 class="section-title">Even <a href="//Karl-Voit.at/2016/10/31/my-temporal-article">a heading should</a> work</h2></header>
+	  <header><h2 class="section-title">Even <a href="https://Karl-Voit.at/2016/10/31/my-temporal-article">a heading should</a> work</h2></header>
 
 
 <p>
 
-What about <a href="//Karl-Voit.at/2016/10/31/an-hidden-blog-entry">a hidden entry</a>?
+What about <a href="https://Karl-Voit.at/2016/10/31/an-hidden-blog-entry">a hidden entry</a>?
 
 </p>
 
@@ -308,7 +308,7 @@ An example with a non-existent ID:
 
 <p>
 
-Example link that exists: <a href="//Karl-Voit.at/2020/10/02/Heading-which-starts-with-a-list">existing link</a>
+Example link that exists: <a href="https://Karl-Voit.at/2020/10/02/Heading-which-starts-with-a-list">existing link</a>
 
 </p>
 
@@ -395,7 +395,7 @@ An example with a non-existent ID:
 
 <p>
 
-Example link that exists: <a href="//Karl-Voit.at/2020/10/02/Heading-which-starts-with-a-list">existing link</a>
+Example link that exists: <a href="https://Karl-Voit.at/2020/10/02/Heading-which-starts-with-a-list">existing link</a>
 
 </p>
 
@@ -795,21 +795,21 @@ Maybe <this> should not be sanitized?
 <div xmlns='http://www.w3.org/1999/xhtml'>
 <p>
 
-<a href="//Karl-Voit.at/2016/10/31/an-hidden-blog-entry">Link to a hidden entry</a>
+<a href="https://Karl-Voit.at/2016/10/31/an-hidden-blog-entry">Link to a hidden entry</a>
 
 </p>
 
 
 <p>
 
-<a href="//Karl-Voit.at/persistent-entry">Link to persistent article</a>
+<a href="https://Karl-Voit.at/persistent-entry">Link to persistent article</a>
 
 </p>
 
 
 <p>
 
-<a href="//Karl-Voit.at/tags/exampletag">Link to tag page</a>
+<a href="https://Karl-Voit.at/tags/exampletag">Link to tag page</a>
 
 </p>
 
@@ -832,21 +832,21 @@ Novum possit temporibus his in. Eam ut scripserit reformidans conclusionemque. O
 	
 <p>
 
-<a href="//Karl-Voit.at/2016/10/31/an-hidden-blog-entry">Link to a hidden entry</a>
+<a href="https://Karl-Voit.at/2016/10/31/an-hidden-blog-entry">Link to a hidden entry</a>
 
 </p>
 
 
 <p>
 
-<a href="//Karl-Voit.at/persistent-entry">Link to persistent article</a>
+<a href="https://Karl-Voit.at/persistent-entry">Link to persistent article</a>
 
 </p>
 
 
 <p>
 
-<a href="//Karl-Voit.at/tags/exampletag">Link to tag page</a>
+<a href="https://Karl-Voit.at/tags/exampletag">Link to tag page</a>
 
 </p>
 
@@ -1033,7 +1033,7 @@ Here, you can read about the test-tag "programming".
 
 <p>
 
-<a href="//Karl-Voit.at/tags/programming">This link</a> should be a self-reference.
+<a href="https://Karl-Voit.at/tags/programming">This link</a> should be a self-reference.
 
 </p>
 
@@ -1056,7 +1056,7 @@ Here, you can read about the test-tag "programming".
 
 <p>
 
-<a href="//Karl-Voit.at/tags/programming">This link</a> should be a self-reference.
+<a href="https://Karl-Voit.at/tags/programming">This link</a> should be a self-reference.
 
 </p>
 

--- a/testdata/end_to_end_test/comparison/feeds/lazyblorg-all.atom_1.0.links-and-teaser.xml
+++ b/testdata/end_to_end_test/comparison/feeds/lazyblorg-all.atom_1.0.links-and-teaser.xml
@@ -64,21 +64,21 @@ This is a test article which tests its links to other (internal) blog entries.
 </p>
 
 <ul>
-<li>This should work <a href="//Karl-Voit.at/persistent-entry">in lists</a> as <a href="//Karl-Voit.at/2016/11/27/special-characters">well</a>.</li>
-<li>This should work <a href="//Karl-Voit.at/persistent-entry">2016-10-31-persistent-entry</a> and <a href="//Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a>.</li>
+<li>This should work <a href="https://Karl-Voit.at/persistent-entry">in lists</a> as <a href="https://Karl-Voit.at/2016/11/27/special-characters">well</a>.</li>
+<li>This should work <a href="https://Karl-Voit.at/persistent-entry">2016-10-31-persistent-entry</a> and <a href="https://Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a>.</li>
 </ul>
 
 <table>
 <tbody>
 <tr class="odd">
 <td>also in</td>
-<td>a <a href="//Karl-Voit.at/2016/11/27/special-characters">table</a></td>
-<td>with <a href="//Karl-Voit.at/2016/11/27/special-characters">multiple cells containing links</a></td>
+<td>a <a href="https://Karl-Voit.at/2016/11/27/special-characters">table</a></td>
+<td>with <a href="https://Karl-Voit.at/2016/11/27/special-characters">multiple cells containing links</a></td>
 </tr>
 <tr class="even">
 <td>also</td>
-<td><a href="//Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
-<td>and <a href="//Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
+<td><a href="https://Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
+<td>and <a href="https://Karl-Voit.at/2016/11/27/special-characters">2016-11-27-special-characters</a></td>
 </tr>
 </tbody>
 </table>
@@ -89,7 +89,7 @@ This is a test article which tests its links to other (internal) blog entries.
 
 <p>
 
-Here is <a href="//Karl-Voit.at/2017/09/30/link-test">a self-reference</a> which should not result in a backlink to itself.
+Here is <a href="https://Karl-Voit.at/2017/09/30/link-test">a self-reference</a> which should not result in a backlink to itself.
 
 </p>
 </div>
@@ -162,7 +162,7 @@ An example with a non-existent ID:
 
 <p>
 
-Example link that exists: <a href="//Karl-Voit.at/2020/10/02/Heading-which-starts-with-a-list">existing link</a>
+Example link that exists: <a href="https://Karl-Voit.at/2020/10/02/Heading-which-starts-with-a-list">existing link</a>
 
 </p>
 
@@ -353,21 +353,21 @@ Being curious how this is going to work out.
 <div xmlns='http://www.w3.org/1999/xhtml'>
 <p>
 
-<a href="//Karl-Voit.at/2016/10/31/an-hidden-blog-entry">Link to a hidden entry</a>
+<a href="https://Karl-Voit.at/2016/10/31/an-hidden-blog-entry">Link to a hidden entry</a>
 
 </p>
 
 
 <p>
 
-<a href="//Karl-Voit.at/persistent-entry">Link to persistent article</a>
+<a href="https://Karl-Voit.at/persistent-entry">Link to persistent article</a>
 
 </p>
 
 
 <p>
 
-<a href="//Karl-Voit.at/tags/exampletag">Link to tag page</a>
+<a href="https://Karl-Voit.at/tags/exampletag">Link to tag page</a>
 
 </p>
 
@@ -489,7 +489,7 @@ Here, you can read about the test-tag "programming".
 
 <p>
 
-<a href="//Karl-Voit.at/tags/programming">This link</a> should be a self-reference.
+<a href="https://Karl-Voit.at/tags/programming">This link</a> should be a self-reference.
 
 </p>
 

--- a/testdata/end_to_end_test/comparison/how-to-use-public-voit/index.html
+++ b/testdata/end_to_end_test/comparison/how-to-use-public-voit/index.html
@@ -92,7 +92,7 @@ This is a placeholder entry in order to be able to test internal links.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2017-01-03-how-to-use-public-voit%20comment:%20&body=Please%20do%20not%20remove%20'2017-01-03-how-to-use-public-voit%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2017-01-03-how-to-use-public-voit%20comment:%20&body=Please%20do%20not%20remove%20'2017-01-03-how-to-use-public-voit%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/persistent-entry/index.html
+++ b/testdata/end_to_end_test/comparison/persistent-entry/index.html
@@ -108,7 +108,7 @@ Novum possit temporibus his in. Eam ut scripserit reformidans conclusionemque. O
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-10-31-persistent-entry%20comment:%20&body=Please%20do%20not%20remove%20'2016-10-31-persistent-entry%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-10-31-persistent-entry%20comment:%20&body=Please%20do%20not%20remove%20'2016-10-31-persistent-entry%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/tags/exampletag/index.html
+++ b/testdata/end_to_end_test/comparison/tags/exampletag/index.html
@@ -168,7 +168,7 @@ Below this, I expect some links to other pages related to the tag "exampletag":
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-10-31-a-tag-page%20comment:%20&body=Please%20do%20not%20remove%20'2016-10-31-a-tag-page%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2016-10-31-a-tag-page%20comment:%20&body=Please%20do%20not%20remove%20'2016-10-31-a-tag-page%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/tags/lazyblorg/index.html
+++ b/testdata/end_to_end_test/comparison/tags/lazyblorg/index.html
@@ -121,7 +121,7 @@
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=lb_tag-lazyblorg%20comment:%20&body=Please%20do%20not%20remove%20'lb_tag-lazyblorg%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=lb_tag-lazyblorg%20comment:%20&body=Please%20do%20not%20remove%20'lb_tag-lazyblorg%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/tags/mytest/index.html
+++ b/testdata/end_to_end_test/comparison/tags/mytest/index.html
@@ -117,7 +117,7 @@
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=lb_tag-mytest%20comment:%20&body=Please%20do%20not%20remove%20'lb_tag-mytest%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=lb_tag-mytest%20comment:%20&body=Please%20do%20not%20remove%20'lb_tag-mytest%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/tags/programming/index.html
+++ b/testdata/end_to_end_test/comparison/tags/programming/index.html
@@ -146,7 +146,7 @@ Glad you like it.
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2014-03-08-lbtag-programming%20comment:%20&body=Please%20do%20not%20remove%20'2014-03-08-lbtag-programming%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=2014-03-08-lbtag-programming%20comment:%20&body=Please%20do%20not%20remove%20'2014-03-08-lbtag-programming%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>

--- a/testdata/end_to_end_test/comparison/tags/testtag1/index.html
+++ b/testdata/end_to_end_test/comparison/tags/testtag1/index.html
@@ -116,7 +116,7 @@
 	  </aside>
 
    <p class="email-comment">
-      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=lb_tag-testtag1%20comment:%20&body=Please%20do%20not%20remove%20'lb_tag-testtag1%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> or via <a href="//disqus.com">Disqus</a> comments below:
+      <a href="mailto:publicvoit-comment@Karl-Voit.at?subject=lb_tag-testtag1%20comment:%20&body=Please%20do%20not%20remove%20'lb_tag-testtag1%20comment:'%20in%20subject%20and%20please%20tell%20me%20whether%20or%20not%20it%20is%20OK%20to%20add%20your%20comment%20and%2For%20your%20name%20and%2For%20your%20email%20address%20to%20the%20blog%20entry!">Comment via email</a> (persistent) or via <a href="//disqus.com">Disqus</a> (ephemeral) comments below:
    </p>
 
     <div id="disqus_thread"></div>


### PR DESCRIPTION
In the RSS feeds the site internal links are local links. This works fine if the feed is loaded from the web site and viewed directly in the browser. If the feed is loaded from local disk in browser the links don't work.

This change generated the links instead of `href="//Karl-Voit.at` as `href="https://Karl-Voit.at`.
