### PR TITLE
config: generify about and how-to placeholders

### DIFF
--- a/config.py
+++ b/config.py
@@ -47,11 +47,11 @@ NUMBER_OF_FEED_ARTICLES = 25
 ## string: This is the Org-mode property :ID: of your blog article which
 ##         is used for the about page of your blog.
 ## See example in: testdata/end_to_end_test/orgfiles/about-placeholder.org
-ID_OF_ABOUT_PAGE = '2014-03-09-about'
+ID_OF_ABOUT_PAGE = 'about'
 
 ## string: This is the Org-mode property :ID: of your blog article which
 ##         is used for the "How to use this blog efficiently" page of your blog.
-ID_OF_HOWTO_PAGE = '2017-01-03-how-to-use-public-voit'
+ID_OF_HOWTO_PAGE = 'how-to-use-this-blog'
 
 ## string: Your Twitter handle/username which is used in the HTML header
 ##         metadata (without the @ character)

--- a/example_invocation.sh
+++ b/example_invocation.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 blog=/tmp/lazyblorg/blog
 # create the output directory (and parents):
@@ -22,5 +23,7 @@ PYTHONPATH="~/src/lazyblorg:" ./lazyblorg.py \
     --orgfiles testdata/end_to_end_test/orgfiles/test.org \
                testdata/end_to_end_test/orgfiles/about-placeholder.org \
                templates/blog-format.org $@
+
+cp -v templates/*.css $blog
 
 #END

--- a/testdata/end_to_end_test/orgfiles/about-placeholder.org
+++ b/testdata/end_to_end_test/orgfiles/about-placeholder.org
@@ -1,28 +1,23 @@
 * DONE Placeholder: About                                   :blog:lazyblorg:lb_persistent:
 CLOSED: [2014-03-09 Sun 14:57]
 :PROPERTIES:
-:CREATED:  [2017-01-03 Tue 12:07]
+:CREATED:  [2014-03-09 Sun 14:30]
+:ID: about
 :END:
 :LOGBOOK:
 - State "DONE"       from "NEXT"       [2014-03-09 Sun 14:57]
 :END:
-:PROPERTIES:
-:CREATED:  [2014-03-09 Sun 14:30]
-:ID: 2014-03-09-about
-:END:
 
-This is a placeholder entry in order to be able to test internal
-links.
+This is a placeholder entry in order to be able to test internal links.
 
 * DONE Placeholder: How to Use This Blog Efficiently                             :blog:lb_persistent:
 CLOSED: [2017-01-03 Tue 12:07]
 :PROPERTIES:
-:ID: 2017-01-03-how-to-use-public-voit
+:ID: how-to-use-this-blog
 :CREATED:  [2017-01-03 Tue 12:07]
 :END:
 :LOGBOOK:
 - State "DONE"       from              [2017-01-03 Tue 12:07]
 :END:
 
-This is a placeholder entry in order to be able to test internal
-links.
+This is a placeholder entry in order to be able to test internal links.


### PR DESCRIPTION
the timestamps in the id don't make sense for such persistent entries