### PR TITLE
implemented URL dictionary with complete error checking

### DIFF
--- a/lib/htmlizer.py
+++ b/lib/htmlizer.py
@@ -32,6 +32,14 @@ except ImportError:
 # NOTE: pdb hides private variables as well. Please use:
 # data = self._OrgParser__entry_data ; data['content']
 
+# MVB initialize link dictionary here as global store
+global dict_of_links
+dict_of_links = {}
+
+# set checking for link definitions to strict: any re-definition will raise
+# a critical error
+LINKDEFS_STRICT_CHECKING = True
+
 
 class HtmlizerException(Exception):
     """
@@ -79,7 +87,7 @@ class Htmlizer(object):
     # populated in copy_cust_link_image_file()
     # { 'basefilename': [ width, height ] }
     dict_of_image_files_with_width_height = { }
-
+    
     # holds a list of tags whose tag pages have been generated
     list_of_tag_pages_generated = []
 
@@ -91,14 +99,20 @@ class Htmlizer(object):
     ID_DESCRIBED_LINK_REGEX = re.compile(r'(\[\[id:([^\]]+?)\]\[([^\]]+?)\]\])')
 
     # find external links such as [[http(s)://foo.com][bar]]:
+    # MVB :: maybe regexp needs adjustment to exclude [] from allowed characters
     EXT_URL_WITH_DESCRIPTION_REGEX = re.compile(
         r'\[\[(http[^ ]+?)\]\[(.+?)\]\]', flags=re.U)
 
+  # find external links such as [[http(s)://foo.com][bar]]:
+    EXT_TAG_URL_WITH_DESCRIPTION_REGEX = re.compile(
+        r'\[\[([^[\[\]]+?)\]\[([^[\[\]]+?)\]\]', flags=re.U)
+        
     # find external links such as [[foo]]:
     EXT_URL_WITHOUT_DESCRIPTION_REGEX = re.compile(
-        r'\[\[(.+?)\]\]', flags=re.U)
+        r'\[\[([^[\[\]]+?)\]\]', flags=re.U)
 
     # find external links such as http(s)://foo.bar
+    # MVB :: maybe regexp needs adjustment to exclude [] from allowed characters
     EXT_URL_LINK_REGEX = re.compile(
         r'([^"<>\[])(http(s)?:\/\/\S+)', flags=re.U)
 
@@ -193,7 +207,7 @@ class Htmlizer(object):
         """
 
         self.blog_data = self._populate_backreferences(self.blog_data)
-
+        
         self.dict_of_tags_with_ids = self._populate_dict_of_tags_with_ids(
             self.blog_data)
 
@@ -1170,6 +1184,28 @@ class Htmlizer(object):
         self.stats_external_latex_to_html5_conversion += 1
         return pypandoc.convert_text(latex, 'html5', format='latex')
 
+    def check_link_definition_against_dictionary(self, keyword, linkdef):
+        # Check if the tag is already defined in linkdefs
+        if keyword in dict_of_links:
+            if LINKDEFS_STRICT_CHECKING:
+                message=("Htmlizer: Aborting because tag value "
+                         f"for {keyword} is re-defined and strict checking is "
+                         f"enabled.\nNew assignment: {linkdef}\nPrevious "
+                         "assignment: %s" % dict_of_links[keyword])
+                self.logging.critical(message)
+                raise HtmlizerException(self.current_entry_id,message)
+            else:
+                self.logging.debug(f"Htmlizer: Warning! Tag {keyword} "
+                                   "already defined in url dictionary.")
+                # Compare the existing value to the new value
+                if linkdef != dict_of_links[keyword]:
+                    message=("Htmlizer: Aborting because tag value "
+                             f"for {keyword} re-defined differently from the "
+                             f"previous value. \nNew assignment: {linkdef}\nPrevious "
+                             "assignment: %s" % dict_of_links[keyword])
+                    self.logging.critical(message)
+                    raise HtmlizerException(self.current_entry_id,message)
+        
     def sanitize_and_htmlize_blog_content(self, entry):
         """
         Inspects a selection of the entry content data and sanitizes
@@ -1216,7 +1252,21 @@ class Htmlizer(object):
                                          str(entry['id']) +
                                          " is not recognized clearly; using guessed_language_autotag \"unsure\"")
                     entry['autotags']['language'] = 'unsure'
-
+                
+        # set url dictionary MVB
+        # look up our dictionary for link definitions
+        if 'linkdefs' not in entry or not isinstance(entry['linkdefs'], dict):
+            self.logging.debug("Htmlizer: blog entry without url"
+            "dictionary definitions encountered")
+        else:
+            for keyword, linkdef in entry['linkdefs'].items():
+                # handle issues such as re-definition
+                self.check_link_definition_against_dictionary(keyword, linkdef)
+                # we're fine, let's add the definition to the dictionary
+                dict_of_links[keyword] = linkdef
+                self.logging.debug("Htmlizer: instantiate url "
+                "dictionary with definition for %s tag" % keyword)
+            
         # for element in entry['content']:
         for index in range(0, len(entry['content'])):
 
@@ -1573,6 +1623,14 @@ class Htmlizer(object):
 
             else:  # fall-back for all content elements which do not require special treatment:
 
+                # simply handle url link definitions for lists before calling pandoc
+                if entry['content'][index][0] == 'list':
+                    for i, listitem in enumerate(entry['content'][index][1]):
+                        # look up URL dictionary for each listitem to
+                        # evtl. replace content with sanitized
+                        # external links
+                        entry['content'][index][1][i] = self.sanitize_url_dict_links(listitem)
+
                 # entry['content'][index][0] == 'mylist':
                 #  ['table', [u'- an example',
                 #             u'  - list subitem',
@@ -1839,6 +1897,21 @@ class Htmlizer(object):
         @param entry: string
         @param return: sanitized string
         """
+        
+        # Replace directly written URLs with HTML anchor tags
+        def replace_url(match):
+            key, value = match.group(0).strip('[]').split('][')
+            if dict_of_links.get(key):
+                self.logging.debug("Htmlizer: replaced tag %s from url dictionary" % key)
+                return '<a href="{}">{}</a>'.format(dict_of_links[key], value)
+            else:
+                return '<a href="{}">{}</a>'.format(key, value)  # Return the original match if URL is not found in dictionary
+
+        # Replace external links of type [[foo][bar]] with <a href="foo">bar</a>
+        content = re.sub(
+            self.EXT_TAG_URL_WITH_DESCRIPTION_REGEX,
+            replace_url,
+            content)
 
         content = re.sub(
             self.EXT_URL_LINK_REGEX,
@@ -1850,9 +1923,56 @@ class Htmlizer(object):
             r'<a href="\1">\2</a>',
             content)
 
+        def replace_tag(match):
+            key = match.group(0)[2:-2]
+            if key in dict_of_links:
+                self.logging.debug("Htmlizer: replaced tag %s (no description) from url dictionary" % key)
+                return '<a href="{}">{}</a>'.format(dict_of_links[key],dict_of_links[key])
+            else:
+                return '<a href="{}">{}</a>'.format(key, key)  # Return the original match if tag is not found in dictionary
+        
         content = re.sub(
             self.EXT_URL_WITHOUT_DESCRIPTION_REGEX,
-            r'<a href="\1">\1</a>',
+            replace_tag,
+            content)
+
+        return content
+
+    def sanitize_url_dict_links(self, content):
+        """
+        Replaces all external Org-mode links of type [[foo][bar]] with
+        dictionary values if a \#+LINK tag definition exists for foo.
+
+        @param entry: string
+        @param return: sanitized string
+        """
+        
+        # Replace url dictionary tags with actual URL
+        def replace_url(match):
+            key, value = match.group(0).strip('[]').split('][')
+            if dict_of_links.get(key):
+                self.logging.debug("Htmlizer: replaced tag %s from url dictionary" % key)
+                return '[[{}][{}]]'.format(dict_of_links[key], value)
+            else:
+                return '[[{}][{}]]'.format(key, value)  # Return the original match if URL is not found in dictionary
+
+        content = re.sub(
+            self.EXT_TAG_URL_WITH_DESCRIPTION_REGEX,
+            replace_url,
+            content)
+
+        # Replace url dictionary tags with actual URL
+        def replace_tag(match):
+            key = match.group(0)[2:-2]
+            if key in dict_of_links:
+                self.logging.debug("Htmlizer: replaced tag %s (no description) from url dictionary" % key)
+                return '[[{}][{}]]'.format(dict_of_links[key],dict_of_links[key])
+            else:
+                return '[[{}][{}]]'.format(key, key)  # Return the original match if tag is not found in dictionary
+        
+        content = re.sub(
+            self.EXT_URL_WITHOUT_DESCRIPTION_REGEX,
+            replace_tag,
             content)
 
         return content
@@ -2715,7 +2835,7 @@ class Htmlizer(object):
                 return self._save_width_height_to_dict_of_image_files_with_width_height(destinationfile)
 
         # FIXXME: FUTURE? generate scaled version when width/height is set
-
+        
     def _populate_filename_dict(self):
         """
         Locates and parses the directory config.DIRECTORIES_WITH_IMAGE_ORIGINALS for filename index. Result is stored in self.filename_dict.

--- a/lib/orgparser.py
+++ b/lib/orgparser.py
@@ -131,7 +131,7 @@ class OrgParser(object):
     CUST_LINK_IMAGE_REGEX = re.compile(r'^\[\[tsfile:([^\]]+\.(png|jpg|jpeg|svg|gif))+(\]\[(.+))?\]\]$')
     CUST_LINK_IMAGE_FILENAME_IDX = 1
     CUST_LINK_IMAGE_DESCRIPTION_IDX = 4
-
+    
     __filename = ''
 
     # for description please visit: lazyblog.org > Notes > Representation of
@@ -142,6 +142,12 @@ class OrgParser(object):
     __entry_data = {}  # dict of currently parsed blog entry data: gets "filled"
     # while parsing the entry
 
+    
+    # set checking for link definitions to strict: any re-definition will raise
+    # a critical error
+    global LINKDEFS_STRICT_CHECKING
+    LINKDEFS_STRICT_CHECKING = True
+    
     def __init__(self, filename):
         """
         This function handles the communication with the parser object and returns the blog data.
@@ -384,6 +390,30 @@ class OrgParser(object):
             # return number of leading spaces:
             return len(list_item) - len(list_item.lstrip(' '))
 
+    def check_link_definition_against_dictionary(self, linkdefs, tag, url):
+        # Check if the tag is already defined in linkdefs
+        if tag in linkdefs:
+            linkdef = linkdefs[tag]
+            if LINKDEFS_STRICT_CHECKING:
+                message=(f"OrgParser: Aborting because tag "
+                         f"value for {tag} is re-defined and strict checking "
+                         f"is enabled. \nNew assignment: {url}\nPrevious "
+                         f"assignment: {linkdef}")
+                self.logging.critical(message)
+                raise OrgParserException(message)
+            else:
+                self.logging.debug(f"OrgParser: Warning! Tag {tag} "
+                                   "already defined in url dictionary.")
+                
+            # Compare the existing value to the new value
+            if linkdef != url:
+                message=(f"OrgParser: Aborting because tag "
+                         f"value for {tag} re-defined differently from the "
+                         f"previous value. \nNew assignment: {url}\nPrevious "
+                         f"assignment: {linkdef}")
+                self.logging.critical(message)
+                raise OrgParserException(message)
+
     def parse_orgmode_file(self):
         """
         Parses the Org-mode file.
@@ -448,6 +478,25 @@ class OrgParser(object):
 
             line = rawline.rstrip()  # remove trailing whitespace
 
+            # Create a 'linkdefs' dictionary entry for link definitions
+            if line.upper().startswith('#+LINK:'):
+                link_definition = line[7:].strip()
+                tag, url = link_definition.split(None, 1)
+                url = url.strip('"')
+
+                # Ensure 'linkdefs' key exists in __entry_data and initialize if it doesn't
+                linkdefs = self.__entry_data.setdefault('linkdefs', {})
+
+                # check if link definitions are consistent
+                self.check_link_definition_against_dictionary(linkdefs,
+                                                              tag,
+                                                              url)
+
+                linkdefs[tag]=url
+                self.logging.debug(
+                    f"OrgParser: define url dictionary tag {tag} for URL {url}")
+                previous_line = line
+            
             if not state == self.SEARCHING_BLOG_HEADER:  ## limit the output to interesting lines
                 self.logging.debug(
                     "OrgParser: ------------------------------- %s" %


### PR DESCRIPTION
Following our [discussion in this thread](https://github.com/novoid/lazyblorg/issues/107), I created a pull request for the corresponding code changes. The only user-configuration would be the `LINKDEFS_STRICT_CHECKING ` constant set in both of the modified files.

I also had to change some regular expressions (and extend with new ones). I think I improved their robustness, because for instance having two link definitions on the same line/paragraph was not handled in some of the REGEXP.

In org parser, I create `self.__entry_data.('linkdefs')` for each blog article with "#+LINK" entries. This data then populates, in htmlizer, the "dict_of_links" dictionary that is used to check whether a given `[[tag][link]]` or `[[tag]]` needs to be expanded. This happens in the functions sanitizing URLs.

These tag shortcuts should work in normal blog articles and bulleted lists. Other sections handed off to eg pypandoc (probably tables?) would need to be implemented separately, like I did for bulleted "list"s. I will certainly do that, but only whenever I need it.